### PR TITLE
feat: add options for data layer module

### DIFF
--- a/src/data-layer/data-layer.test.ts
+++ b/src/data-layer/data-layer.test.ts
@@ -54,6 +54,21 @@ it('should push events to default target property', () => {
   expect(defaultTargetProperty).toEqual([eventPayloadA, eventPayloadB])
 })
 
+it('should throw error if is server side', () => {
+  const { window } = globalThis
+  // @ts-expect-error removing to test this use case
+  const removeWindowFromEnvironment = () => delete globalThis.window
+  const restoreWindow = () => (globalThis.window = window)
+
+  removeWindowFromEnvironment()
+  const dataLayer = createDataLayer()
+  expect(dataLayer.assertIsAvailable).toThrowError(WarningError)
+  expect(dataLayer.assertIsAvailable).toThrowError(
+    'Triggering events is not possible on server-side.'
+  )
+  restoreWindow()
+})
+
 it('should throw error if targetProperty is not available', () => {
   setDefaultTargetProperty(undefined)
 

--- a/src/data-layer/data-layer.test.ts
+++ b/src/data-layer/data-layer.test.ts
@@ -1,12 +1,17 @@
-import { createDataLayer, getDefaultTargetProperty } from './data-layer'
+import { createDataLayer } from './data-layer'
+import type { EventProperties } from './data-layer-types'
 import { WarningError } from '../error'
 
 function makeDataLayer() {
-  return createDataLayer()
+  const mockTargetProperty: EventProperties[] = []
+  return {
+    mockTargetProperty,
+    dataLayer: createDataLayer({ targetProperty: mockTargetProperty }),
+  }
 }
 
-function resetDefaultTargetProperty() {
-  window.dataLayer = []
+function getDefaultTargetProperty() {
+  return window.dataLayer
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,26 +19,45 @@ function setDefaultTargetProperty(value: any) {
   window.dataLayer = value
 }
 
-beforeEach(resetDefaultTargetProperty)
-
-it('should return the correct default targetProperty', () => {
-  const targetProperty = getDefaultTargetProperty()
-  expect(targetProperty).toBe(window.dataLayer)
+beforeEach(() => {
+  setDefaultTargetProperty([])
 })
 
-it('should push events to global data layer', () => {
-  const dataLayer = makeDataLayer()
-  const targetProperty = getDefaultTargetProperty()
+it('should return different data layer objects', () => {
+  const { dataLayer: dataLayerA } = makeDataLayer()
+  const { dataLayer: dataLayerB } = makeDataLayer()
+  const dataLayerC = createDataLayer({ targetProperty: [] })
+  expect(dataLayerA).not.toBe(dataLayerB)
+  expect(dataLayerB).not.toBe(dataLayerC)
+})
+
+it('should push events to custom target property', () => {
+  const { dataLayer, mockTargetProperty } = makeDataLayer()
   const eventPayloadA = { hello: 'there', isTest: 'yes' }
   const eventPayloadB = { random: 'event', key: 'lorem' }
+
   dataLayer.addEvent(eventPayloadA)
   dataLayer.addEvent(eventPayloadB)
-  expect(targetProperty).toEqual([eventPayloadA, eventPayloadB])
+  expect(mockTargetProperty).toHaveLength(2)
+  expect(mockTargetProperty).toEqual([eventPayloadA, eventPayloadB])
+})
+
+it('should push events to default target property', () => {
+  const dataLayer = createDataLayer()
+  const defaultTargetProperty = getDefaultTargetProperty()
+  const eventPayloadA = { hello: 'there', isTest: 'yes' }
+  const eventPayloadB = { random: 'event', key: 'lorem' }
+
+  dataLayer.addEvent(eventPayloadA)
+  dataLayer.addEvent(eventPayloadB)
+  expect(defaultTargetProperty).toHaveLength(2)
+  expect(defaultTargetProperty).toEqual([eventPayloadA, eventPayloadB])
 })
 
 it('should throw error if targetProperty is not available', () => {
   setDefaultTargetProperty(undefined)
-  const dataLayer = makeDataLayer()
+
+  const dataLayer = createDataLayer()
   expect(dataLayer.assertIsAvailable).toThrowError(WarningError)
   expect(dataLayer.assertIsAvailable).toThrowError(
     'The targetProperty is not defined.'
@@ -42,7 +66,8 @@ it('should throw error if targetProperty is not available', () => {
 
 it('should throw error if targetProperty is not an array', () => {
   setDefaultTargetProperty({})
-  const dataLayer = makeDataLayer()
+
+  const dataLayer = createDataLayer()
   expect(dataLayer.assertIsAvailable).toThrowError(WarningError)
   expect(dataLayer.assertIsAvailable).toThrowError(
     'The targetProperty is not an array.'

--- a/src/data-layer/data-layer.ts
+++ b/src/data-layer/data-layer.ts
@@ -5,20 +5,27 @@ import {
 } from './data-layer-error'
 import type { EventProperties, DataLayerFunctions } from './data-layer-types'
 
-export function getDefaultTargetProperty() {
-  return window.dataLayer
-}
+type DataLayerOptions = Partial<{
+  targetProperty: EventProperties[]
+}>
 
-export function createDataLayer(): DataLayerFunctions {
+export function createDataLayer(
+  options: DataLayerOptions = {}
+): DataLayerFunctions {
+  function getTargetProperty() {
+    const defaultTarget: EventProperties[] = window.dataLayer
+    return options.targetProperty ?? defaultTarget
+  }
+
   function addEvent(payload: EventProperties) {
-    const targetProperty = getDefaultTargetProperty()
+    const targetProperty = getTargetProperty()
     targetProperty.push(payload)
   }
 
   function assertIsAvailable() {
     const isServer = () => typeof window === 'undefined'
-    const isDefined = () => typeof getDefaultTargetProperty() !== 'undefined'
-    const isArray = () => Array.isArray(getDefaultTargetProperty())
+    const isDefined = () => typeof getTargetProperty() !== 'undefined'
+    const isArray = () => Array.isArray(getTargetProperty())
 
     if (isServer()) throwIsServer()
     else if (!isDefined()) throwIsNotDefined()


### PR DESCRIPTION
## Description
This PR changes how the data layer module was handling the `targetProperty`. Now we can provide a custom `targetProperty` options, this makes it easier for testing and for the module to be independent.

In addition to that, I have included more unit tests for different cases for this module.