### PR TITLE
Feat: Add events configuration

### DIFF
--- a/.api-report/gtm-event-tracker.api.md
+++ b/.api-report/gtm-event-tracker.api.md
@@ -4,19 +4,27 @@
 
 ```ts
 
-// @public
-export type Configurations = Partial<{
-    logger: LoggerConfigurations;
-}>;
+import type { PartialDeep } from 'type-fest';
 
 // @public
-export const configure: (customConfigs: Configurations) => void;
+export type Configurations = {
+    logger: LoggerConfigurations;
+    events: EventsConfigurations;
+};
+
+// @public
+export const configure: (customConfigs: PartialDeep<Configurations>) => void;
 
 // @public
 export function createTrackerContext(initialProps?: EventProperties, options?: TrackerContextOptions): TrackerContext;
 
 // @public
 export type EventProperties = Record<string, string | number>;
+
+// @public
+export type EventsConfigurations = {
+    targetProperty: EventProperties[];
+};
 
 // @public
 export type Logger = {
@@ -39,11 +47,11 @@ export type LoggerAction = {
 };
 
 // @public
-export type LoggerConfigurations = Partial<{
+export type LoggerConfigurations = {
     debugAll: boolean;
     debugEvents: boolean;
     debugContext: boolean;
-}>;
+};
 
 // @public
 export const setLogger: (targetLogger: Logger) => void;

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "rimraf": "^3.0.2",
     "semantic-release": "^19.0.2",
     "tsc-alias": "^1.6.7",
+    "type-fest": "^2.13.0",
     "typescript": "^4.6.4"
   }
 }

--- a/src/configuration/configuration-types.ts
+++ b/src/configuration/configuration-types.ts
@@ -1,3 +1,5 @@
+import type { EventProperties } from '@/shared/data-layer'
+
 /**
  * Available options for the logger.
  * @public
@@ -9,9 +11,18 @@ export type LoggerConfigurations = Partial<{
 }>
 
 /**
+ * Available options for events.
+ * @public
+ */
+export type EventsConfigurations = {
+  targetProperty: EventProperties[]
+}
+
+/**
  * All available configuration options.
  * @public
  */
 export type Configurations = Partial<{
   logger: LoggerConfigurations
+  events: EventsConfigurations
 }>

--- a/src/configuration/configuration-types.ts
+++ b/src/configuration/configuration-types.ts
@@ -4,11 +4,11 @@ import type { EventProperties } from '@/shared/data-layer'
  * Available options for the logger.
  * @public
  */
-export type LoggerConfigurations = Partial<{
+export type LoggerConfigurations = {
   debugAll: boolean
   debugEvents: boolean
   debugContext: boolean
-}>
+}
 
 /**
  * Available options for events.
@@ -22,7 +22,7 @@ export type EventsConfigurations = {
  * All available configuration options.
  * @public
  */
-export type Configurations = Partial<{
+export type Configurations = {
   logger: LoggerConfigurations
   events: EventsConfigurations
-}>
+}

--- a/src/configuration/configuration.tests.ts
+++ b/src/configuration/configuration.tests.ts
@@ -8,6 +8,9 @@ const defaultConfigurations = {
     debugEvents: false,
     debugContext: false,
   },
+  events: {
+    targetProperty: window.dataLayer,
+  },
 } as const
 
 it('should initialize configuration with default values', () => {
@@ -66,9 +69,12 @@ it('should not change any configurations', () => {
 
   configuration.configure({ logger: undefined })
   expect(configuration.get()).toEqual(defaultConfigurations)
+
+  configuration.configure({ events: { targetProperty: undefined } })
+  expect(configuration.get()).toEqual(defaultConfigurations)
 })
 
-it('should change logger configurations', () => {
+it('should change specific configurations', () => {
   const configuration = createConfiguration()
   const modifiedConfigurations: Partial<Configurations> = {
     logger: {
@@ -76,6 +82,7 @@ it('should change logger configurations', () => {
       debugContext: true,
       debugEvents: true,
     },
+    events: { ...defaultConfigurations.events },
   }
 
   configuration.configure(modifiedConfigurations)

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,6 +1,7 @@
 import { merge } from 'lodash-es'
 import { throwNoConfigurationProvided } from './configuration-errors'
 import type { Configurations } from './configuration-types'
+import type { PartialDeep } from 'type-fest'
 
 export function createConfiguration() {
   const configurations: Configurations = defaults()
@@ -12,14 +13,17 @@ export function createConfiguration() {
         debugEvents: false,
         debugContext: false,
       },
+      events: {
+        targetProperty: window.dataLayer,
+      },
     }
   }
 
-  function get() {
+  function get(): Configurations {
     return configurations
   }
 
-  function configure(customConfigs: Configurations) {
+  function configure(customConfigs: PartialDeep<Configurations>) {
     const isConfigDefined = Boolean(customConfigs)
     if (!isConfigDefined) throwNoConfigurationProvided()
     merge(configurations, customConfigs)

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -2,4 +2,5 @@ export { configuration, configure } from './configuration'
 export type {
   Configurations,
   LoggerConfigurations,
+  EventsConfigurations,
 } from './configuration-types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@ export {
   configure,
   Configurations,
   LoggerConfigurations,
+  EventsConfigurations,
 } from '@/configuration'

--- a/src/shared/data-layer/data-layer.ts
+++ b/src/shared/data-layer/data-layer.ts
@@ -28,7 +28,7 @@ export function createDataLayer(options: DataLayerOptions = {}): DataLayer {
 
   function checkTargetPropertyAvailability() {
     const isServer = () => typeof window === 'undefined'
-    const isDefined = () => typeof getTargetProperty() !== 'undefined'
+    const isDefined = () => Boolean(getTargetProperty())
     const isArray = () => Array.isArray(getTargetProperty())
 
     if (isServer()) throwIsServer()

--- a/src/shared/data-layer/data-layer.ts
+++ b/src/shared/data-layer/data-layer.ts
@@ -3,16 +3,21 @@ import {
   throwIsNotDefined,
   throwIsServer,
 } from './data-layer-error'
+import { configuration, Configurations } from '@/configuration'
 import type { EventProperties, DataLayer } from './data-layer-types'
 
 type DataLayerOptions = Partial<{
-  targetProperty: EventProperties[]
+  configurations: Configurations
 }>
 
 export function createDataLayer(options: DataLayerOptions = {}): DataLayer {
+  function getConfiguration(): Configurations {
+    return options.configurations ?? configuration.get()
+  }
+
   function getTargetProperty() {
-    const defaultTarget: EventProperties[] = window.dataLayer
-    return options.targetProperty ?? defaultTarget
+    const configurations = getConfiguration()
+    return configurations.events.targetProperty
   }
 
   function addEvent(payload: EventProperties) {

--- a/src/with-tracker/with-tracker.test.ts
+++ b/src/with-tracker/with-tracker.test.ts
@@ -1,35 +1,11 @@
 import { createTrackerContext } from '@/tracker-context'
 import { withTrackerContext } from './with-tracker'
-import { WarningError } from '@/shared/error'
 import type { EventProperties } from '@/shared/data-layer'
 
 function makeTracker(props?: EventProperties) {
   const context = createTrackerContext(props)
   return withTrackerContext(context)
 }
-
-beforeEach(() => {
-  window.dataLayer = []
-})
-
-it('should throw error if window.dataLayer is not available', () => {
-  // @ts-expect-error deleting for purposes of this test
-  delete window.dataLayer
-
-  const tracker = makeTracker()
-  const trackEmptyEvent = () => tracker.trackEvent({})
-
-  expect(trackEmptyEvent).toThrowError(WarningError)
-})
-
-it('should throw error if window.dataLayer is not an array', () => {
-  // @ts-expect-error changing for purposes of this test
-  window.dataLayer = {}
-  const tracker = makeTracker()
-  const trackEmptyEvent = () => tracker.trackEvent({})
-
-  expect(trackEmptyEvent).toThrowError(WarningError)
-})
 
 it('should contain all composed properties in the events', () => {
   const contextProps = { foo: 'bar', baz: 'quz' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8103,6 +8103,11 @@ type-fest@^1.0.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
+type-fest@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.13.0.tgz#d1ecee38af29eb2e863b22299a3d68ef30d2abfb"
+  integrity sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==
+
 typescript@^4.4.3:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"


### PR DESCRIPTION
## Description
This Pull Request adds the `EventsConfigurations`, which will be used to provide configuration for events.

## Changes
Now the Data Layer doesn't depend directly on the `window.dataLayer`, this logic is defined as a default configuration, within the Configuration module.
