### PR TITLE
fix: upgrade pnpm/action-setup to v5 for Node.js 24 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 


### PR DESCRIPTION
## Summary
- Upgrade `pnpm/action-setup` from v4 to v5 to fix Node.js 20 deprecation warning

## Context
GitHub Actions is deprecating Node.js 20. The `pnpm/action-setup@v4` runs on Node.js 20 and triggers a deprecation warning. Version 5 supports Node.js 24.